### PR TITLE
Octokit

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@ The bot kernel is designed to:
 - Interface with plugins (GitHub Actions) for longer running processes.
 - Run on Cloudflare Workers.
 
+## Environment variables
+
+- PRIVATE_KEY
+You need to get a private key from Github App settings and convert it to PKCS#8 using this command:
+`openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in pkcs8.key -out pkcs8.key`
+
+- WEBHOOK_SECRET
+You need to set it in Github App settings and also set it here.
+
+- APP_ID
+You can find this in Github App settings.
+
+- WEBHOOK_PROXY_URL (only for development)
+You need to get a webhook URL at <https://smee.io/> and set it in the Github App settings
+
 ### Quick Start
 
 ```bash

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,12 +1,14 @@
 import { EmitterWebhookEvent as WebhookEvent, EmitterWebhookEventName as WebhookEventName } from "@octokit/webhooks";
+import { customOctokit } from "./octokit";
 
 export class Context<T extends WebhookEventName = WebhookEventName> {
   public key: WebhookEventName;
   public name: WebhookEventName;
   public id: string;
   public payload: WebhookEvent<T>["payload"];
+  public octokit: InstanceType<typeof customOctokit>;
 
-  constructor(event: WebhookEvent<T>) {
+  constructor(event: WebhookEvent<T>, octokit: InstanceType<typeof customOctokit>) {
     this.name = event.name;
     this.id = event.id;
     this.payload = event.payload;
@@ -15,6 +17,7 @@ export class Context<T extends WebhookEventName = WebhookEventName> {
     } else {
       this.key = this.name;
     }
+    this.octokit = octokit;
   }
 }
 

--- a/src/event-handler.ts
+++ b/src/event-handler.ts
@@ -1,5 +1,12 @@
 import { Webhooks } from "@octokit/webhooks";
 import { Context, SimplifiedContext } from "./context";
+import { customOctokit } from "./octokit";
+
+export type Options = {
+  webhookSecret: string;
+  appId: string | number;
+  privateKey: string;
+};
 
 export class EventHandler {
   public webhooks: Webhooks<SimplifiedContext>;
@@ -7,13 +14,51 @@ export class EventHandler {
   public onAny: Webhooks<SimplifiedContext>["onAny"];
   public onError: Webhooks<SimplifiedContext>["onError"];
 
-  constructor(secret: string) {
+  private _webhookSecret: string;
+  private _privateKey: string;
+  private _appId: number;
+
+  constructor(options: Options) {
+    this._privateKey = options.privateKey;
+    this._appId = Number(options.appId);
+    /*const key = crypto.subtle
+      .importKey(
+        "pkcs8",
+        new TextEncoder().encode(this.privateKey),
+        {
+          name: "RSASSA-PKCS1-v1_5",
+          hash: "SHA-256",
+        },
+        true,
+        []
+      )
+      .then((key) => {
+        crypto.subtle.exportKey("s", key).then((keydata) => {
+          console.log(keydata);
+        });
+      });*/
+
+    this._webhookSecret = options.webhookSecret;
+
     this.webhooks = new Webhooks<SimplifiedContext>({
-      secret,
+      secret: this._webhookSecret,
       transform: (event) => {
-        return new Context(event);
+        let installationId: number | undefined = undefined;
+        if ("installation" in event.payload) {
+          installationId = event.payload.installation?.id;
+        }
+        const octokit = new customOctokit({
+          auth: {
+            appId: this._appId,
+            privateKey: this._privateKey,
+            installationId: installationId,
+          },
+        });
+
+        return new Context(event, octokit);
       },
     });
+
     this.on = this.webhooks.on;
     this.onAny = this.webhooks.onAny;
     this.onError = this.webhooks.onError;

--- a/src/handlers/issue/comment_created.ts
+++ b/src/handlers/issue/comment_created.ts
@@ -2,4 +2,11 @@ import { Context } from "../../context";
 
 export async function handleIssueCommentCreated(event: Context<"issue_comment.created">) {
   console.log(event);
+
+  await event.octokit.issues.createComment({
+    owner: event.payload.repository.owner.login,
+    repo: event.payload.repository.name,
+    issue_number: event.payload.issue.number,
+    body: "Hello from the worker!",
+  });
 }

--- a/src/handlers/issue/comment_created.ts
+++ b/src/handlers/issue/comment_created.ts
@@ -1,7 +1,10 @@
 import { Context } from "../../context";
 
 export async function handleIssueCommentCreated(event: Context<"issue_comment.created">) {
-  console.log(event);
+  if (event.payload.comment.user.type === "Bot") {
+    console.log("Skipping bot comment");
+    return;
+  }
 
   await event.octokit.issues.createComment({
     owner: event.payload.repository.owner.login,

--- a/src/octokit.ts
+++ b/src/octokit.ts
@@ -1,0 +1,53 @@
+import { Octokit } from "@octokit/core";
+import { RequestOptions } from "@octokit/types";
+import { paginateRest } from "@octokit/plugin-paginate-rest";
+import { legacyRestEndpointMethods } from "@octokit/plugin-rest-endpoint-methods";
+import { retry } from "@octokit/plugin-retry";
+import { throttling } from "@octokit/plugin-throttling";
+import { createAppAuth } from "@octokit/auth-app";
+
+const defaultOptions = {
+  authStrategy: createAppAuth,
+  throttle: {
+    onAbuseLimit: (retryAfter: number, options: RequestOptions, octokit: Octokit) => {
+      octokit.log.warn(`Abuse limit hit with "${options.method} ${options.url}", retrying in ${retryAfter} seconds.`);
+      return true;
+    },
+    onRateLimit: (retryAfter: number, options: RequestOptions, octokit: Octokit) => {
+      octokit.log.warn(`Rate limit hit with "${options.method} ${options.url}", retrying in ${retryAfter} seconds.`);
+      return true;
+    },
+    onSecondaryRateLimit: (retryAfter: number, options: RequestOptions, octokit: Octokit) => {
+      octokit.log.warn(`Secondary rate limit hit with "${options.method} ${options.url}", retrying in ${retryAfter} seconds.`);
+      return true;
+    },
+  },
+};
+
+function requestLogging(octokit: Octokit) {
+  octokit.hook.error("request", (error, options) => {
+    if ("status" in error) {
+      const { method, url, body } = octokit.request.endpoint.parse(options);
+      const msg = `GitHub request: ${method} ${url} - ${error.status}`;
+
+      // @ts-expect-error log.debug is a pino log method and accepts a fields object
+      octokit.log.debug(body || {}, msg);
+    }
+
+    throw error;
+  });
+
+  octokit.hook.after("request", (result, options) => {
+    const { method, url, body } = octokit.request.endpoint.parse(options);
+    const msg = `GitHub request: ${method} ${url} - ${result.status}`;
+
+    // @ts-expect-error log.debug is a pino log method and accepts a fields object
+    octokit.log.debug(body || {}, msg);
+  });
+}
+
+export const customOctokit = Octokit.plugin(throttling, retry, paginateRest, legacyRestEndpointMethods, requestLogging).defaults(
+  (instanceOptions: object) => {
+    return Object.assign({}, defaultOptions, instanceOptions);
+  }
+);

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -1,4 +1,4 @@
 import { Type as T, type Static } from "@sinclair/typebox";
 
-export const envSchema = T.Object({ WEBHOOK_SECRET: T.String() });
+export const envSchema = T.Object({ WEBHOOK_SECRET: T.String(), APP_ID: T.String(), PRIVATE_KEY: T.String() });
 export type Env = Static<typeof envSchema>;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -70,7 +70,7 @@ export default {
       });
     }
 
-    const eventHandler = new EventHandler(env.WEBHOOK_SECRET);
+    const eventHandler = new EventHandler({ webhookSecret: env.WEBHOOK_SECRET, appId: env.APP_ID, privateKey: env.PRIVATE_KEY });
     bindHandlers(eventHandler);
 
     try {


### PR DESCRIPTION
There is an issue regarding private key. Github generates a private key in PKCS#1 format but Octokit wants PKCS#8. It's possible to convert it to PKCS#8 using Node's crypto module but Cloudflare's crypto module is different and doesn't support PKCS#1.

Cloudflare has [Node compatibility](https://developers.cloudflare.com/workers/runtime-apis/nodejs/) option but it looks like they don't have [createPrivateKey](https://developers.cloudflare.com/workers/runtime-apis/nodejs/crypto/#keys) implemented in the crypto module which we need for this conversion to work. 
Most third-party libraries rely on Node so it's not an option either.

We could put instructions in the README to convert it to PKCS#8 using `openssl` but I'd like to avoid that if possible because I think it's bad DX but maybe it's our only option.
@pavlovcik what do you think?

