### PR TITLE
Default config bug

### DIFF
--- a/src/github/types/plugin-configuration.ts
+++ b/src/github/types/plugin-configuration.ts
@@ -52,7 +52,7 @@ const pluginChainSchema = T.Array(
     type: T.Union([T.Literal("github")], { default: "github" }),
     with: T.Record(T.String(), T.Unknown(), { default: {} }),
   }),
-  { minItems: 1 }
+  { minItems: 1, default: [] }
 );
 
 export type PluginChain = StaticDecode<typeof pluginChainSchema>;

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -128,7 +128,7 @@ describe("Worker tests", () => {
                   data: `
                   plugins:
                     issue_comment.created:
-                      - name: "Run on commment created"
+                      - name: "Run on comment created"
                         uses:
                           - id: plugin-A
                             plugin: https://plugin-a.internal

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -109,6 +109,46 @@ describe("Worker tests", () => {
       } as unknown as GitHubContext);
       expect(cfg).toBeTruthy();
     });
+    it("Should fill the config with defaults", async () => {
+      const cfg = await getConfig({
+        key: issueOpened,
+        name: issueOpened,
+        id: "",
+        payload: {
+          repository: {
+            owner: { login: "ubiquity" },
+            name: "ubiquibot-kernel",
+          },
+        } as unknown as GitHubContext<"issues.closed">["payload"],
+        octokit: {
+          rest: {
+            repos: {
+              getContent() {
+                return {
+                  data: `
+                  plugins:
+                    issue_comment.created:
+                      - name: "Run on commment created"
+                        uses:
+                          - id: plugin-A
+                            plugin: https://plugin-a.internal
+                  `,
+                };
+              },
+            },
+          },
+        },
+        eventHandler: {} as GitHubEventHandler,
+      } as unknown as GitHubContext);
+      expect(cfg).toBeTruthy();
+      const pluginChain = cfg.plugins["issue_comment.created"];
+      expect(pluginChain.length).toBe(1);
+      expect(pluginChain[0].uses.length).toBe(1);
+      expect(pluginChain[0].skipBotEvents).toBeTrue();
+      expect(pluginChain[0].uses[0].id).toBe("plugin-A");
+      expect(pluginChain[0].uses[0].plugin).toBe("https://plugin-a.internal");
+      expect(pluginChain[0].uses[0].with).toEqual({});
+    });
     it("Should merge the configuration when found", async () => {
       const cfg = await getConfig({
         key: issueOpened,


### PR DESCRIPTION
I encountered this bug so many times but never understood why typebox doesn't use default values inside `uses` objects. 

Well after a headache and trying different things it turned out that the array needs to have default set to `[]` even though the array always has at least one object because of the `minItems` constraint.
