### PR TITLE
fix!: removed GitHub type from the configuration

### DIFF
--- a/src/github/types/plugin-configuration.ts
+++ b/src/github/types/plugin-configuration.ts
@@ -50,7 +50,6 @@ const pluginChainSchema = T.Array(
   T.Object({
     id: T.Optional(T.String()),
     plugin: githubPluginType(),
-    type: T.Union([T.Literal("github")], { default: "github" }),
     with: T.Record(T.String(), T.Unknown(), { default: {} }),
   }),
   { minItems: 1, default: [] }

--- a/tests/configuration.test.ts
+++ b/tests/configuration.test.ts
@@ -8,7 +8,7 @@ import { GitHubEventHandler } from "../src/github/github-event-handler";
 
 config({ path: ".dev.vars" });
 
-mock.module("@octokit/webhooks", () => ({
+void mock.module("@octokit/webhooks", () => ({
   Webhooks: WebhooksMocked,
 }));
 
@@ -66,7 +66,6 @@ plugins:
               workflowId: "compute.yml",
               ref: "pull/1",
             },
-            type: "github",
             with: {
               settings1: "enabled",
             },

--- a/tests/configuration.test.ts
+++ b/tests/configuration.test.ts
@@ -46,7 +46,6 @@ plugins:
   'issues.labeled':
     - uses:
       - plugin: ubiquity/user-activity-watcher:compute.yml@pull/1
-        type: github
         with:
           settings1: 'enabled'`,
               };

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -158,12 +158,10 @@ plugins:
   '*':
     - uses:
       - plugin: repo-3/plugin-3
-        type: github
         with:
           setting1: false
     - uses:
       - plugin: repo-1/plugin-1
-        type: github
         with:
           setting2: true`,
                   };
@@ -174,18 +172,15 @@ plugins:
   'issues.assigned':
     - uses:
       - plugin: uses-1/plugin-1
-        type: github
         with:
           settings1: 'enabled'
   '*':
     - uses:
       - plugin: repo-1/plugin-1
-        type: github
         with:
           setting1: false
     - uses:
       - plugin: repo-2/plugin-2
-        type: github
         with:
           setting2: true`,
                 };

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -204,7 +204,6 @@ plugins:
                 repo: "plugin-1",
                 workflowId,
               },
-              type: "github",
               with: {
                 settings1: "enabled",
               },
@@ -222,7 +221,6 @@ plugins:
                 repo: "plugin-3",
                 workflowId,
               },
-              type: "github",
               with: {
                 setting1: false,
               },
@@ -238,7 +236,6 @@ plugins:
                 repo: "plugin-1",
                 workflowId,
               },
-              type: "github",
               with: {
                 setting2: true,
               },


### PR DESCRIPTION
Resolves #45 

On merge, need to update https://github.com/ubiquity/ubiquibot-config/blob/development/.github/.ubiquibot-config.yml
<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
