### PR TITLE
ci: fix cspell

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -4,7 +4,7 @@
   "ignorePaths": ["**/*.json", "**/*.css", "node_modules", "**/*.log"],
   "useGitignore": true,
   "language": "en",
-  "words": ["dataurl", "devpool", "fkey", "outdir", "servedir", "supabase", "typebox", "ubiquibot", "smee", "tomlify"],
+  "words": ["dataurl", "devpool", "fkey", "mswjs", "outdir", "servedir", "supabase", "typebox", "ubiquibot", "smee", "tomlify"],
   "dictionaries": ["typescript", "node", "software-terms"],
   "import": ["@cspell/dict-typescript/cspell-ext.json", "@cspell/dict-node/cspell-ext.json", "@cspell/dict-software-terms"],
   "ignoreRegExpList": ["[0-9a-fA-F]{6}"]

--- a/.github/knip.ts
+++ b/.github/knip.ts
@@ -5,7 +5,7 @@ const config: KnipConfig = {
   project: ["src/**/*.ts"],
   ignoreBinaries: ["build", "i", "format:cspell", "awk", "lsof"],
   ignoreExportsUsedInFile: true,
-  ignoreDependencies: ["@mswjs/data", "esbuild", "eslint-config-prettier", "eslint-plugin-prettier"],
+  ignoreDependencies: ["@mswjs/data", "esbuild", "eslint-config-prettier", "eslint-plugin-prettier", "msw"],
 };
 
 export default config;


### PR DESCRIPTION
This PR fixes:
1. [cpell](https://github.com/ubiquity/ubiquibot-kernel/actions/runs/9583290400) CI error
2. [knip](https://github.com/ubiquity/ubiquibot-kernel/actions/runs/9583407536) CI error (notice that since knip workflow uses `pull_request_target` changes will be seen only after this PR is merged)